### PR TITLE
Force push fresh autodocs to github pages

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -21,4 +21,4 @@ jobs:
         run: |
           mkdir docs
           pip install portray
-          portray on_github_pages
+          portray on_github_pages -f


### PR DESCRIPTION
After any tested commit to master, it will force update https://veryfi.github.io/veryfi-python/ from docs generated from the commit.