### PR TITLE
Install deps in update-docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -21,4 +21,5 @@ jobs:
         run: |
           mkdir docs
           pip install portray
+          pip install -r requirements.txt
           portray on_github_pages -f

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+3.1.1
+-----
+* Install dependencies in update-docs workflow
+
 3.1.0
 -----
 * Add support for operations with line items


### PR DESCRIPTION
This PR prevents portray build from breaking.