### PR TITLE
Pin lower bound version on pydantic to `pydantic>=1.9.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.22.0
-pydantic==1.9.0
+pydantic>=1.9.0


### PR DESCRIPTION
Instead of pinning to a specific version, it's probably best to define a lower bound.

This helps projects upgrade pydantic to the latest version avoiding issues such as 

```
Because veryfi (3.2.0) depends on pydantic (1.9.0)
 and myproject depends on pydantic (1.10.2), veryfi is forbidden.
So, because myproject depends on veryfi (3.2.0), version solving failed.
```

I saw that there weren't any fancy pydantic features being used. So this should be safe, but i can add tests if needed.