### PR TITLE
Pin lower bound on Pydantic as >=1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.22.0
-pydantic==1.*
+pydantic>=1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, report
+envlist = py37, py38, py39, py310, py311, py312, report
 skipsdist = true
 skip_install = true
 basepython = py37
@@ -9,6 +9,9 @@ python =
     3.7: py37
     3.8: py38, report
     3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
 
 [base]
 deps =
@@ -46,4 +49,3 @@ fail_under = 82
 precision = 2
 skip_covered = True
 skip_empty = True
-

--- a/veryfi/model.py
+++ b/veryfi/model.py
@@ -3,20 +3,20 @@ from pydantic import BaseModel
 
 
 class SharedLineItem(BaseModel):
-    sku: Optional[str]
-    category: Optional[str]
-    tax: Optional[float]
-    price: Optional[float]
-    unit_of_measure: Optional[str]
-    quantity: Optional[float]
-    upc: Optional[str]
-    tax_rate: Optional[float]
-    discount_rate: Optional[float]
-    start_date: Optional[str]
-    end_date: Optional[str]
-    hsn: Optional[str]
-    section: Optional[str]
-    weight: Optional[str]
+    sku: Optional[str] = None
+    category: Optional[str] = None
+    tax: Optional[float] = None
+    price: Optional[float] = None
+    unit_of_measure: Optional[str] = None
+    quantity: Optional[float] = None
+    upc: Optional[str] = None
+    tax_rate: Optional[float] = None
+    discount_rate: Optional[float] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    hsn: Optional[str] = None
+    section: Optional[str] = None
+    weight: Optional[str] = None
 
 
 class AddLineItem(SharedLineItem):
@@ -26,6 +26,6 @@ class AddLineItem(SharedLineItem):
 
 
 class UpdateLineItem(SharedLineItem):
-    order: Optional[int]
-    description: Optional[str]
-    total: Optional[float]
+    order: Optional[int] = None
+    description: Optional[str] = None
+    total: Optional[float] = None


### PR DESCRIPTION
## Changelog
- Pin lower bound on Pydantic as >=1
- Fix pydantic BaseModel definitions to add a default value.
   See [here](https://github.com/pydantic/pydantic/discussions/2353) for more information.
- Update tox tests to include new python versions i.e. 3.10, 3.11, 3.12

## Notes
1. Follow up to #40 to pin lower bound on pydantic, unblocking v2 on projects.
 Also related to #34 earlier was was undone in #40. I assume the intent was to allow all v1.* and not just >=1.9.0 as in #34 


2. Pydantic has now dropped support for python <=3.8. See [here(https://docs.pydantic.dev/latest/changelog/#changes_3)
  I didn't want to remove it as part of this PR. But i think the verfyi client should follow in the next release. 3.8 is basically being dropped in a lot of places recently.