### PR TITLE
Update release workflow, bump version to 5.0.1, and fix signup URL

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -6,26 +6,31 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install build tox tox-gh-actions
+
       - name: Build package
         env:
           SKIP_GENERATE_AUTHORS: 1
         run: |
           pip install -U setuptools wheel pbr
-          python setup.py sdist bdist_wheel
+          python -m build
+          
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Requires Python 3.9 or later.
 
 ### Obtaining credentials
 
-If you don't have a Veryfi account, register at [hub.veryfi.com/signup/api/](https://hub.veryfi.com/signup/api/).
+If you don't have a Veryfi account, register at [app.veryfi.com/signup/api/](https://app.veryfi.com/signup/api/).
 
 ### Initialize the client
 

--- a/veryfi/client_base.py
+++ b/veryfi/client_base.py
@@ -1,4 +1,3 @@
-import requests
 import base64
 import hashlib
 import hmac
@@ -6,11 +5,12 @@ import json
 import time
 from typing import Dict, Optional
 
+import requests
+
 from veryfi.errors import VeryfiClientError
 
 
 class Client:
-
     API_VERSION = "v8"
     API_TIMEOUT = 30
     BASE_URL = "https://api.veryfi.com/api/"
@@ -42,13 +42,15 @@ class Client:
         :return: Dictionary with headers
         """
         final_headers = {
-            "User-Agent": "Python Veryfi-Python/5.0.0",
+            "User-Agent": "Python Veryfi-Python/5.0.1",
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Client-Id": self.client_id,
         }
 
-        final_headers.update({"Authorization": f"apikey {self.username}:{self.api_key}"})
+        final_headers.update(
+            {"Authorization": f"apikey {self.username}:{self.api_key}"}
+        )
 
         return final_headers
 
@@ -108,6 +110,8 @@ class Client:
 
         secret_bytes = bytes(self.client_secret, "utf-8")
         payload_bytes = bytes(payload, "utf-8")
-        tmp_signature = hmac.new(secret_bytes, msg=payload_bytes, digestmod=hashlib.sha256).digest()
+        tmp_signature = hmac.new(
+            secret_bytes, msg=payload_bytes, digestmod=hashlib.sha256
+        ).digest()
         base64_signature = base64.b64encode(tmp_signature).decode("utf-8").strip()
         return base64_signature

--- a/veryfi/client_base.py
+++ b/veryfi/client_base.py
@@ -48,9 +48,7 @@ class Client:
             "Client-Id": self.client_id,
         }
 
-        final_headers.update(
-            {"Authorization": f"apikey {self.username}:{self.api_key}"}
-        )
+        final_headers.update({"Authorization": f"apikey {self.username}:{self.api_key}"})
 
         return final_headers
 
@@ -110,8 +108,6 @@ class Client:
 
         secret_bytes = bytes(self.client_secret, "utf-8")
         payload_bytes = bytes(payload, "utf-8")
-        tmp_signature = hmac.new(
-            secret_bytes, msg=payload_bytes, digestmod=hashlib.sha256
-        ).digest()
+        tmp_signature = hmac.new(secret_bytes, msg=payload_bytes, digestmod=hashlib.sha256).digest()
         base64_signature = base64.b64encode(tmp_signature).decode("utf-8").strip()
         return base64_signature


### PR DESCRIPTION
## Summary

- **Release workflow** (`release-pypi.yml`): upgrade to `ubuntu-latest`, `actions/checkout@v4`, `actions/setup-python@v5`, switch to `python -m build`, add `contents: read` permission
- **Version bump**: User-Agent updated from `5.0.0` → `5.0.1` in `client_base.py`
- **Code style**: apply black formatting to `client_base.py`
- **README**: fix signup URL from `hub.veryfi.com` → `app.veryfi.com`

## Test plan

- [ ] CI passes on push
- [ ] Release workflow builds and publishes correctly on next GitHub release

Made with [Cursor](https://cursor.com)