### PR TITLE
Add veryfi CLI for shell and AI agent usage

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ tox = "*"
 
 [packages]
 requests = "*"
+typer = ">=0.12.0"
 
 [requires]
 python_version = "3.9"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Extract structured data from receipts, invoices, bank statements, checks, W-2s, 
   - [Any Document](#any-document)
   - [Classify](#classify)
 - [Error Handling](#error-handling)
+- [Command-line interface](#command-line-interface)
 - [Contributing](#contributing)
 - [Need Help?](#need-help)
 - [Changelog](#changelog)
@@ -366,6 +367,118 @@ except VeryfiClientError as e:
 
 ---
 
+## Command-line interface
+
+Installing `veryfi` also installs a `veryfi` console script (and the equivalent `python -m veryfi`). The CLI is a thin wrapper around the Python `Client` and exposes every supported resource as a sub-command — designed for shell users and AI agents that drive the SDK from a terminal.
+
+Verify the install:
+
+```bash
+veryfi --help
+# or, equivalently:
+python -m veryfi --help
+```
+
+### Authentication
+
+Credentials are read from environment variables (preferred for agents) or equivalent flags:
+
+| Env var | Flag | Description |
+|---------|------|-------------|
+| `VERYFI_CLIENT_ID` | `--client-id` | Required |
+| `VERYFI_CLIENT_SECRET` | `--client-secret` | Optional — enables HMAC request signing |
+| `VERYFI_USERNAME` | `--username` | Required |
+| `VERYFI_API_KEY` | `--api-key` | Required |
+| `VERYFI_BASE_URL` | `--base-url` | Optional, defaults to `https://api.veryfi.com/api/` |
+| `VERYFI_API_VERSION` | `--api-version` | Optional, defaults to `v8` |
+| `VERYFI_TIMEOUT` | `--timeout` | Optional, defaults to `30` seconds |
+
+If any required credential is missing the CLI exits with code `2` and a JSON error on stderr.
+
+### Quick examples
+
+```bash
+export VERYFI_CLIENT_ID=... VERYFI_USERNAME=... VERYFI_API_KEY=...
+# Optional:
+export VERYFI_CLIENT_SECRET=...
+
+# Documents
+veryfi documents process --file /tmp/receipt.jpg --category Travel --category Meals
+veryfi documents process-url --file-url https://cdn.example.com/x.pdf --boost-mode --external-id ref-1
+veryfi documents list --q Walgreens --created-gt 2024-01-01+00:00:00
+veryfi documents get 933760836
+veryfi documents update 933760836 --field category="Meals & Entertainment" --field total=11.23
+veryfi documents delete 933760836
+
+# Nested line-items / tags
+veryfi documents line-items add 933760836 --field description="Extra item" --field total=5.0
+veryfi documents tags add-many 933760836 --tag q1 --tag travel
+
+# Multi-page PDF splitting
+veryfi documents set split --file /tmp/multi.pdf
+veryfi documents set split-url --file-url https://cdn.example.com/multi.pdf --max-pages 5
+
+# Other resources
+veryfi bank-statements process --file /tmp/stmt.pdf --category Transfer
+veryfi checks process-with-remittance --file /tmp/check.pdf
+veryfi business-cards process-url --file-url https://cdn.example.com/card.jpg
+veryfi w2s process --file /tmp/w2.pdf
+veryfi w2s set split --file /tmp/multi_w2.pdf
+veryfi w8s list --created-gt 2024-01-01+00:00:00
+veryfi w9s get 33333
+veryfi any-docs process --blueprint my_blueprint --file /tmp/custom.pdf
+veryfi classify file --file /tmp/unknown.pdf --document-type receipt --document-type invoice
+```
+
+You can also pipe binary file data via stdin by passing `--file -`:
+
+```bash
+curl -s https://cdn.example.com/r.jpg | veryfi documents process --file -
+```
+
+### Output and exit codes
+
+Every command emits a JSON response on stdout. Use `--output raw` for single-line JSON (handy for piping into `jq`) or `--output pretty` for sorted keys. Errors are emitted as JSON on **stderr** and the process exits with a non-zero status:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `2` | Missing credentials or invalid CLI arguments |
+| `1`-`255` | Veryfi API error — exit code is the HTTP status (clipped to 255) |
+| `70` | Unexpected error (treat as a bug) |
+
+The exact HTTP status is always included in the stderr payload, e.g.:
+
+```json
+{
+  "error": "Document not found",
+  "status": 404,
+  "exception": "ResourceNotFound"
+}
+```
+
+### Passing arbitrary fields
+
+For endpoints that accept `**kwargs` (e.g. `update_document`, `add_line_item`, `update_check`), use repeatable `--field KEY=VALUE` flags or `--json-body '<json>'`. `--field` values are JSON-decoded when possible (so `total=11.23` becomes a number, `enabled=true` becomes a boolean, `data='{"a":1}'` becomes an object) and fall back to plain strings.
+
+### Discovery
+
+Every command at every level supports `--help`, which lists subcommands or options with their descriptions:
+
+```bash
+veryfi --help                        # top-level: lists all resource groups
+veryfi documents --help              # group: lists process, list, get, tags, line-items, set, …
+veryfi documents process --help      # leaf: lists every flag with its description
+```
+
+For AI agents and tooling that prefer a machine-readable contract, `veryfi schema` emits a JSON manifest of every command, its description, and every parameter (name, type, required, repeatable). Agents can ingest this once to register Veryfi as a tool surface without parsing `--help` text:
+
+```bash
+veryfi schema | jq '.commands[] | {name, help}'
+```
+
+---
+
 ## Contributing
 
 Contributions are welcome! To get started:
@@ -377,6 +490,8 @@ Contributions are welcome! To get started:
 pip install -r requirements.txt
 pip install black pytest responses tox
 ```
+
+`requirements.txt` already includes `typer`, which is required for the `veryfi` CLI and its tests.
 
 3. Make your changes, then run the test suite:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.22.0
+typer>=0.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,13 @@ keywords = veryfi, veryfi.com, ocr api
 
 [options]
 packages = find:
+install_requires =
+    requests>=2.22.0
+    typer>=0.12.0
 
 
 [entry_points]
 pbr.config.drivers =
     plain = pbr.cfg.driver:Plain
+console_scripts =
+    veryfi = veryfi.cli:app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,497 @@
+"""CLI tests.
+
+These exercise the Typer surface end-to-end using :class:`typer.testing.CliRunner`
+and ``responses`` to mock the underlying HTTP layer. They verify that:
+
+- credentials are sourced from env vars (or rejected when missing),
+- happy-path commands wrap each SDK method with the right HTTP shape,
+- ``VeryfiClientError`` is mapped to the HTTP status as exit code,
+- the ``schema`` command exposes the full command tree for agent discovery.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterator
+
+import pytest
+import responses
+from typer.testing import CliRunner
+
+from veryfi.cli import app
+
+CREDS_ENV = {
+    "VERYFI_CLIENT_ID": "cid",
+    "VERYFI_CLIENT_SECRET": "csecret",
+    "VERYFI_USERNAME": "user",
+    "VERYFI_API_KEY": "key",
+}
+
+BASE = "https://api.veryfi.com/api/v8/partner"
+ASSET = os.path.join(os.path.dirname(__file__), "assets", "receipt_public.jpg")
+
+
+def _make_runner() -> CliRunner:
+    """Build a CliRunner with stdout/stderr split when supported.
+
+    Click <8.2 used ``mix_stderr=False`` to opt into split streams; in 8.2+
+    streams are split by default and the kwarg was removed. We accept both.
+    """
+    try:
+        return CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+    except TypeError:
+        return CliRunner()
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return _make_runner()
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict]:
+    """Populate Veryfi credential env vars for tests that hit `get_client`."""
+    for key, value in CREDS_ENV.items():
+        monkeypatch.setenv(key, value)
+    yield dict(CREDS_ENV)
+
+
+# --- discovery ---------------------------------------------------------------
+
+
+def test_help_lists_all_resource_groups(runner: CliRunner) -> None:
+    """`veryfi --help` must surface every SDK resource as a sub-command."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for group in (
+        "documents",
+        "bank-statements",
+        "checks",
+        "business-cards",
+        "w2s",
+        "w8s",
+        "w9s",
+        "any-docs",
+        "classify",
+        "schema",
+    ):
+        assert group in result.stdout
+
+
+def test_subcommand_help_does_not_require_credentials(runner: CliRunner) -> None:
+    """`--help` is always free of side effects, even without auth."""
+    result = runner.invoke(app, ["documents", "process", "--help"])
+    assert result.exit_code == 0
+    assert "--file" in result.stdout
+    assert "--category" in result.stdout
+
+
+def test_schema_emits_full_command_tree(runner: CliRunner) -> None:
+    """`schema` is the machine-readable counterpart to `--help` for agents."""
+    result = runner.invoke(app, ["schema"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    top_level = {c["name"] for c in payload["commands"]}
+    assert {
+        "documents",
+        "bank-statements",
+        "checks",
+        "business-cards",
+        "w2s",
+        "w8s",
+        "w9s",
+        "any-docs",
+        "classify",
+        "schema",
+    } <= top_level
+
+    docs = next(c for c in payload["commands"] if c["name"] == "documents")
+    doc_cmd_names = {c["name"] for c in docs["commands"]}
+    assert {"process", "process-url", "list", "get", "update", "delete"} <= doc_cmd_names
+
+    process_cmd = next(c for c in docs["commands"] if c["name"] == "process")
+    flag_names = {p["name"] for p in process_cmd["params"]}
+    assert {"file", "categories", "delete_after_processing"} <= flag_names
+
+
+# --- credential handling ----------------------------------------------------
+
+
+def test_missing_credentials_exit_code_2(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in CREDS_ENV:
+        monkeypatch.delenv(key, raising=False)
+    result = runner.invoke(app, ["documents", "get", "1"])
+    assert result.exit_code == 2
+    payload = json.loads(result.stderr)
+    assert payload["error"] == "missing credentials"
+    assert set(payload["missing_env_vars"]) >= {
+        "VERYFI_CLIENT_ID",
+        "VERYFI_USERNAME",
+        "VERYFI_API_KEY",
+    }
+
+
+def test_cli_flags_override_env(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit `--client-id` etc. must take precedence over env vars."""
+    for key, value in CREDS_ENV.items():
+        monkeypatch.setenv(key, f"env-{value}")
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, f"{BASE}/documents/1/", json={"id": 1}, status=200)
+        result = runner.invoke(
+            app,
+            [
+                "--client-id",
+                "flag-cid",
+                "--username",
+                "flag-user",
+                "--api-key",
+                "flag-key",
+                "documents",
+                "get",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert rsps.calls[0].request.headers.get("Client-Id") == "flag-cid"
+        assert "flag-user:flag-key" in rsps.calls[0].request.headers.get("Authorization", "")
+
+
+# --- happy paths -------------------------------------------------------------
+
+
+@responses.activate
+def test_documents_get(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.GET, f"{BASE}/documents/42/", json={"id": 42}, status=200)
+    result = runner.invoke(app, ["documents", "get", "42"])
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout) == {"id": 42}
+
+
+@responses.activate
+def test_documents_list_passes_query_params(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.GET, f"{BASE}/documents/", json=[{"id": 1}], status=200)
+    result = runner.invoke(
+        app,
+        [
+            "documents",
+            "list",
+            "--q",
+            "Walgreens",
+            "--created-gt",
+            "2024-01-01+00:00:00",
+            "--param",
+            "page=2",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    call = responses.calls[0]
+    assert "q=Walgreens" in call.request.url
+    assert "created__gt=2024-01-01" in call.request.url
+    assert "page=2" in call.request.url
+
+
+@responses.activate
+def test_documents_update_merges_field_and_json_body(runner: CliRunner, env: dict) -> None:
+    responses.add(
+        responses.PUT,
+        f"{BASE}/documents/7/",
+        json={"id": 7, "total": 11.23, "category": "Travel", "notes": "x"},
+        status=200,
+    )
+    result = runner.invoke(
+        app,
+        [
+            "documents",
+            "update",
+            "7",
+            "--json-body",
+            json.dumps({"notes": "x", "category": "Meals"}),
+            "--field",
+            "total=11.23",
+            "--field",
+            "category=Travel",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body == {"total": 11.23, "category": "Travel", "notes": "x"}
+
+
+@responses.activate
+def test_documents_update_requires_payload(runner: CliRunner, env: dict) -> None:
+    result = runner.invoke(app, ["documents", "update", "7"])
+    assert result.exit_code != 0
+    assert "at least one --field or --json-body" in result.stderr
+
+
+@responses.activate
+def test_documents_delete_emits_deleted_marker(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.DELETE, f"{BASE}/documents/9/", json={}, status=200)
+    result = runner.invoke(app, ["documents", "delete", "9"])
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout) == {"deleted": 9}
+
+
+@responses.activate
+def test_documents_process_uploads_file(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.POST, f"{BASE}/documents/", json={"id": 1}, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "documents",
+            "process",
+            "--file",
+            ASSET,
+            "--category",
+            "Travel",
+            "--category",
+            "Meals",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body["file_name"] == "receipt_public.jpg"
+    assert body["categories"] == ["Travel", "Meals"]
+    assert body["auto_delete"] is False
+    assert body["file_data"], "file_data should be base64-encoded payload"
+
+
+@responses.activate
+def test_documents_process_url_requires_url(runner: CliRunner, env: dict) -> None:
+    result = runner.invoke(app, ["documents", "process-url"])
+    assert result.exit_code != 0
+    assert "--file-url" in result.stderr
+
+
+@responses.activate
+def test_classify_url(runner: CliRunner, env: dict) -> None:
+    responses.add(
+        responses.POST, f"{BASE}/classify/", json={"document_type": "receipt"}, status=200
+    )
+    result = runner.invoke(
+        app,
+        [
+            "classify",
+            "url",
+            "--file-url",
+            "https://cdn.example.com/x.pdf",
+            "--document-type",
+            "receipt",
+            "--document-type",
+            "invoice",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body["file_url"] == "https://cdn.example.com/x.pdf"
+    assert body["document_types"] == ["receipt", "invoice"]
+
+
+@responses.activate
+def test_bank_statements_process_url(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.POST, f"{BASE}/bank-statements/", json={"id": 5}, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "bank-statements",
+            "process-url",
+            "--file-url",
+            "https://cdn.example.com/s.pdf",
+            "--category",
+            "Transfer",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body["file_url"] == "https://cdn.example.com/s.pdf"
+    assert body["categories"] == ["Transfer"]
+
+
+@responses.activate
+def test_checks_with_remittance_url(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.POST, f"{BASE}/check-with-document/", json={"id": 1}, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "checks",
+            "process-with-remittance-url",
+            "--file-url",
+            "https://cdn.example.com/c.pdf",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+
+
+@responses.activate
+def test_business_cards_process_url(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.POST, f"{BASE}/business-cards/", json={"id": 1}, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "business-cards",
+            "process-url",
+            "--file-url",
+            "https://cdn.example.com/card.jpg",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+
+
+@responses.activate
+def test_w2s_split_url(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.POST, f"{BASE}/w2s-set/", json={"id": 1}, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "w2s",
+            "set",
+            "split-url",
+            "--file-url",
+            "https://cdn.example.com/w2.pdf",
+            "--max-pages",
+            "3",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body["file_url"] == "https://cdn.example.com/w2.pdf"
+    assert body["max_pages_to_process"] == 3
+
+
+@responses.activate
+def test_w8s_get(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.GET, f"{BASE}/w-8ben-e/3/", json={"id": 3}, status=200)
+    result = runner.invoke(app, ["w8s", "get", "3"])
+    assert result.exit_code == 0, result.stderr
+
+
+@responses.activate
+def test_w9s_delete(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.DELETE, f"{BASE}/w9s/4/", json={}, status=200)
+    result = runner.invoke(app, ["w9s", "delete", "4"])
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout) == {"deleted": 4}
+
+
+@responses.activate
+def test_any_docs_process_url(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.POST, f"{BASE}/any-documents/", json={"id": 1}, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "any-docs",
+            "process-url",
+            "--blueprint",
+            "blueprint_x",
+            "--file-url",
+            "https://cdn.example.com/x.pdf",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body["blueprint_name"] == "blueprint_x"
+
+
+@responses.activate
+def test_documents_tags_add(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.PUT, f"{BASE}/documents/1/tags/", json={"id": 11}, status=200)
+    result = runner.invoke(app, ["documents", "tags", "add", "1", "--name", "reimbursable"])
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body == {"name": "reimbursable"}
+
+
+@responses.activate
+def test_documents_line_items_add_requires_payload(runner: CliRunner, env: dict) -> None:
+    result = runner.invoke(app, ["documents", "line-items", "add", "1"])
+    assert result.exit_code != 0
+    assert "at least one --field or --json-body" in result.stderr
+
+
+@responses.activate
+def test_documents_line_items_add(runner: CliRunner, env: dict) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE}/documents/1/line-items/",
+        json={"id": 99},
+        status=200,
+    )
+    result = runner.invoke(
+        app,
+        [
+            "documents",
+            "line-items",
+            "add",
+            "1",
+            "--field",
+            "description=Extra item",
+            "--field",
+            "total=5.0",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    body = json.loads(responses.calls[0].request.body)
+    assert body == {"description": "Extra item", "total": 5.0}
+
+
+# --- error mapping ----------------------------------------------------------
+
+
+@responses.activate
+def test_error_status_becomes_exit_code(runner: CliRunner, env: dict) -> None:
+    """4xx/5xx errors exit non-zero (clipped to 1-255) with JSON on stderr.
+
+    The HTTP status is exposed in the JSON payload so agents can branch on
+    the precise status even when POSIX exit code limits force clipping.
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE}/documents/999/",
+        json={"status": "fail", "error": "Document not found"},
+        status=404,
+    )
+    result = runner.invoke(app, ["documents", "get", "999"])
+    assert result.exit_code != 0
+    assert result.exit_code <= 255
+    payload = json.loads(result.stderr)
+    assert payload["status"] == 404
+    assert payload["error"] == "Document not found"
+    assert payload["exception"] == "ResourceNotFound"
+
+
+@responses.activate
+def test_unauthorized_status(runner: CliRunner, env: dict) -> None:
+    """401 is propagated as exit code 401 (within the 1-255 POSIX range)."""
+    responses.add(
+        responses.GET,
+        f"{BASE}/documents/1/",
+        json={"status": "fail", "error": "bad creds"},
+        status=401,
+    )
+    result = runner.invoke(app, ["documents", "get", "1"])
+    assert result.exit_code == 255  # 401 clips down to 255 (max POSIX exit code)
+    payload = json.loads(result.stderr)
+    assert payload["status"] == 401
+    assert payload["exception"] == "UnauthorizedAccessToken"
+
+
+# --- output formatting ------------------------------------------------------
+
+
+@responses.activate
+def test_output_raw_is_single_line(runner: CliRunner, env: dict) -> None:
+    responses.add(responses.GET, f"{BASE}/documents/1/", json={"id": 1, "x": [1, 2]}, status=200)
+    result = runner.invoke(app, ["--output", "raw", "documents", "get", "1"])
+    assert result.exit_code == 0, result.stderr
+    assert "\n" not in result.stdout.rstrip("\n")
+    assert json.loads(result.stdout) == {"id": 1, "x": [1, 2]}
+
+
+def test_invalid_output_value(runner: CliRunner, env: dict) -> None:
+    result = runner.invoke(app, ["--output", "yaml", "schema"])
+    assert result.exit_code != 0
+    assert "--output" in result.stderr

--- a/veryfi/__main__.py
+++ b/veryfi/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m veryfi`` as an alias for the installed ``veryfi`` CLI."""
+
+from veryfi.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/veryfi/cli/__init__.py
+++ b/veryfi/cli/__init__.py
@@ -1,0 +1,201 @@
+"""Veryfi command-line interface.
+
+The CLI is a thin Typer wrapper around :class:`veryfi.Client`. It exposes
+one sub-app per Veryfi resource (documents, bank-statements, checks, …)
+so AI agents and shell users can drive the SDK from the command line.
+
+Output is JSON on stdout, errors are JSON on stderr, and exit codes mirror
+the HTTP status of the underlying API error.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import typer
+
+from veryfi.cli import (
+    a_docs as _a_docs,
+    bank_statements as _bank_statements,
+    business_cards as _business_cards,
+    checks as _checks,
+    classify as _classify,
+    documents as _documents,
+    w2s as _w2s,
+    w8s as _w8s,
+    w9s as _w9s,
+)
+from veryfi.cli._common import build_state
+
+app = typer.Typer(
+    name="veryfi",
+    help=(
+        "Veryfi OCR API command-line client. Credentials may be supplied via "
+        "VERYFI_CLIENT_ID, VERYFI_CLIENT_SECRET, VERYFI_USERNAME, VERYFI_API_KEY "
+        "(plus optional VERYFI_BASE_URL, VERYFI_API_VERSION, VERYFI_TIMEOUT) "
+        "or the equivalent --flags. Results are emitted as JSON on stdout."
+    ),
+    add_completion=False,
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+app.add_typer(_documents.app, name="documents")
+app.add_typer(_bank_statements.app, name="bank-statements")
+app.add_typer(_checks.app, name="checks")
+app.add_typer(_business_cards.app, name="business-cards")
+app.add_typer(_w2s.app, name="w2s")
+app.add_typer(_w8s.app, name="w8s")
+app.add_typer(_w9s.app, name="w9s")
+app.add_typer(_a_docs.app, name="any-docs")
+app.add_typer(_classify.app, name="classify")
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    client_id: Optional[str] = typer.Option(
+        None,
+        "--client-id",
+        envvar="VERYFI_CLIENT_ID",
+        help="Veryfi client_id. Overrides VERYFI_CLIENT_ID.",
+        show_envvar=False,
+    ),
+    client_secret: Optional[str] = typer.Option(
+        None,
+        "--client-secret",
+        envvar="VERYFI_CLIENT_SECRET",
+        help="Veryfi client_secret. Enables HMAC request signing.",
+        show_envvar=False,
+    ),
+    username: Optional[str] = typer.Option(
+        None,
+        "--username",
+        envvar="VERYFI_USERNAME",
+        help="Veryfi account username. Overrides VERYFI_USERNAME.",
+        show_envvar=False,
+    ),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        envvar="VERYFI_API_KEY",
+        help="Veryfi account API key. Overrides VERYFI_API_KEY.",
+        show_envvar=False,
+    ),
+    base_url: Optional[str] = typer.Option(
+        None,
+        "--base-url",
+        envvar="VERYFI_BASE_URL",
+        help="API base URL. Defaults to https://api.veryfi.com/api/.",
+        show_envvar=False,
+    ),
+    api_version: Optional[str] = typer.Option(
+        None,
+        "--api-version",
+        envvar="VERYFI_API_VERSION",
+        help="API version, e.g. v8.",
+        show_envvar=False,
+    ),
+    timeout: Optional[int] = typer.Option(
+        None,
+        "--timeout",
+        envvar="VERYFI_TIMEOUT",
+        help="Per-request timeout in seconds. Defaults to 30.",
+        show_envvar=False,
+    ),
+    output: str = typer.Option(
+        "json",
+        "--output",
+        "-o",
+        case_sensitive=False,
+        help="Output format: json (indented, default), raw (single-line), pretty (sorted keys).",
+    ),
+) -> None:
+    """Build a shared state object exposed to every subcommand via ``ctx.obj``."""
+    normalised = output.lower()
+    if normalised not in {"json", "raw", "pretty"}:
+        raise typer.BadParameter(f"--output must be one of: json, raw, pretty (got {output!r})")
+
+    ctx.obj = build_state(
+        client_id=client_id,
+        client_secret=client_secret,
+        username=username,
+        api_key=api_key,
+        base_url=base_url,
+        api_version=api_version,
+        timeout=timeout,
+        output=normalised,
+    )
+
+
+@app.command("schema")
+def schema_command(ctx: typer.Context) -> None:
+    """Emit a JSON manifest of every CLI command for agent tool discovery.
+
+    The manifest lists each command path, its help text, and the parameters
+    (name, type, required, help). Agents can use this to register Veryfi as
+    a tool surface without parsing ``--help`` text.
+    """
+    typer.echo(json.dumps(_build_schema(app), indent=2, default=str))
+
+
+def _build_schema(typer_app: typer.Typer) -> dict:
+    """Walk the Typer app graph and produce a serialisable description."""
+    import click
+    from typer.main import get_command
+
+    cli: click.Command = get_command(typer_app)
+    return _describe_command(cli, [])
+
+
+def _describe_command(command, path):  # type: ignore[no-untyped-def]
+    import click
+
+    name = command.name or ""
+    full_path = path + ([name] if name else [])
+    entry: dict = {
+        "name": name,
+        "path": full_path,
+        "help": (command.help or "").strip(),
+    }
+    if isinstance(command, click.Group):
+        entry["commands"] = [
+            _describe_command(command.get_command(None, sub), full_path)
+            for sub in sorted(command.list_commands(None))
+        ]
+    else:
+        entry["params"] = [_describe_param(p) for p in command.params]
+    return entry
+
+
+def _describe_param(param):  # type: ignore[no-untyped-def]
+    import click
+
+    info: dict = {
+        "name": param.name,
+        "kind": "argument" if isinstance(param, click.Argument) else "option",
+        "required": bool(param.required),
+        "multiple": bool(getattr(param, "multiple", False)),
+        "default": _serialise_default(param.default),
+    }
+    if isinstance(param, click.Option):
+        info["flags"] = list(param.opts) + list(param.secondary_opts)
+        info["help"] = (param.help or "").strip()
+        info["is_flag"] = bool(param.is_flag)
+        info["envvar"] = param.envvar
+    info["type"] = getattr(param.type, "name", str(param.type))
+    return info
+
+
+def _serialise_default(value):  # type: ignore[no-untyped-def]
+    if callable(value):
+        return None
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return repr(value)
+
+
+__all__ = ["app"]

--- a/veryfi/cli/_common.py
+++ b/veryfi/cli/_common.py
@@ -1,0 +1,315 @@
+"""Shared helpers for the Veryfi CLI.
+
+Centralises:
+- Building a :class:`veryfi.Client` from env vars / global flags.
+- Emitting JSON results to stdout in a consistent shape.
+- Converting :class:`veryfi.errors.VeryfiClientError` to an exit code + JSON
+  on stderr so AI agents can branch on the result without parsing tracebacks.
+- Parsing repeatable ``--field KEY=VALUE`` flags into kwargs for SDK methods
+  that take ``**kwargs``.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+import sys
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import typer
+
+from veryfi import Client
+from veryfi.errors import VeryfiClientError
+
+ENV_PREFIX = "VERYFI_"
+
+EnvKeys = {
+    "client_id": f"{ENV_PREFIX}CLIENT_ID",
+    "client_secret": f"{ENV_PREFIX}CLIENT_SECRET",
+    "username": f"{ENV_PREFIX}USERNAME",
+    "api_key": f"{ENV_PREFIX}API_KEY",
+    "base_url": f"{ENV_PREFIX}BASE_URL",
+    "api_version": f"{ENV_PREFIX}API_VERSION",
+    "timeout": f"{ENV_PREFIX}TIMEOUT",
+}
+
+
+class CtxState:
+    """Container stored on Typer's context object.
+
+    We avoid carrying Typer-specific types in business logic and treat this
+    as a plain settings bag built once in the root callback.
+    """
+
+    __slots__ = (
+        "client_id",
+        "client_secret",
+        "username",
+        "api_key",
+        "base_url",
+        "api_version",
+        "timeout",
+        "output",
+        "_client",
+    )
+
+    def __init__(self) -> None:
+        self.client_id: Optional[str] = None
+        self.client_secret: Optional[str] = None
+        self.username: Optional[str] = None
+        self.api_key: Optional[str] = None
+        self.base_url: Optional[str] = None
+        self.api_version: Optional[str] = None
+        self.timeout: Optional[int] = None
+        self.output: str = "json"
+        self._client: Optional[Client] = None
+
+
+def _from_env(name: str) -> Optional[str]:
+    value = os.environ.get(EnvKeys[name])
+    return value if value not in (None, "") else None
+
+
+def build_state(
+    client_id: Optional[str],
+    client_secret: Optional[str],
+    username: Optional[str],
+    api_key: Optional[str],
+    base_url: Optional[str],
+    api_version: Optional[str],
+    timeout: Optional[int],
+    output: str,
+) -> CtxState:
+    """Merge CLI flags over env-var defaults into a :class:`CtxState`."""
+    state = CtxState()
+    state.client_id = client_id or _from_env("client_id")
+    # client_secret is optional in the SDK (HMAC signing is only applied when set).
+    state.client_secret = client_secret if client_secret is not None else _from_env("client_secret")
+    state.username = username or _from_env("username")
+    state.api_key = api_key or _from_env("api_key")
+    state.base_url = base_url or _from_env("base_url")
+    state.api_version = api_version or _from_env("api_version")
+
+    if timeout is None:
+        raw = _from_env("timeout")
+        state.timeout = int(raw) if raw is not None else None
+    else:
+        state.timeout = timeout
+
+    state.output = output
+    return state
+
+
+def get_client(ctx: typer.Context) -> Client:
+    """Return a memoised :class:`veryfi.Client` for the current invocation.
+
+    Missing required credentials produce a usage error (exit code 2) with a
+    machine-readable JSON payload on stderr so agents can detect misconfig.
+    """
+    state: CtxState = ctx.obj
+    if state._client is not None:
+        return state._client
+
+    missing = [
+        EnvKeys[name] for name in ("client_id", "username", "api_key") if not getattr(state, name)
+    ]
+    if missing:
+        _print_error(
+            {
+                "error": "missing credentials",
+                "missing_env_vars": missing,
+                "hint": (
+                    "Set the env vars listed above or pass --client-id / "
+                    "--username / --api-key (and optionally --client-secret)."
+                ),
+            }
+        )
+        raise typer.Exit(code=2)
+
+    kwargs: Dict[str, Any] = {
+        "client_id": state.client_id,
+        "client_secret": state.client_secret or "",
+        "username": state.username,
+        "api_key": state.api_key,
+    }
+    if state.base_url:
+        kwargs["base_url"] = state.base_url
+    if state.api_version:
+        kwargs["api_version"] = state.api_version
+    if state.timeout is not None:
+        kwargs["timeout"] = state.timeout
+
+    state._client = Client(**kwargs)
+    return state._client
+
+
+def emit(ctx: typer.Context, result: Any) -> None:
+    """Serialise an SDK response (or any JSON-friendly value) to stdout."""
+    state: CtxState = ctx.obj
+    output = state.output if state else "json"
+
+    if result is None:
+        if output == "raw":
+            return
+        result = {"ok": True}
+
+    if output == "raw":
+        typer.echo(json.dumps(result, default=str, separators=(",", ":")))
+    elif output == "pretty":
+        typer.echo(json.dumps(result, default=str, indent=2, sort_keys=True))
+    else:
+        typer.echo(json.dumps(result, default=str, indent=2))
+
+
+def _print_error(payload: Dict[str, Any]) -> None:
+    typer.echo(json.dumps(payload, default=str, indent=2), err=True)
+
+
+def handle_errors(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that maps SDK errors to JSON-on-stderr + non-zero exit codes.
+
+    Exit code is the HTTP status of the error (clipped to 1-255). Generic
+    SDK errors without a status fall through as exit code 1. Unexpected
+    exceptions exit with code 70 (EX_SOFTWARE).
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except typer.Exit:
+            raise
+        except VeryfiClientError as exc:
+            status = getattr(exc, "status", None) or 1
+            payload: Dict[str, Any] = {
+                "error": getattr(exc, "error", None) or str(exc),
+                "status": status,
+            }
+            code = getattr(exc, "code", None)
+            if code is not None:
+                payload["code"] = code
+            payload["exception"] = type(exc).__name__
+            _print_error(payload)
+            raise typer.Exit(code=max(1, min(int(status), 255)))
+        except FileNotFoundError as exc:
+            _print_error({"error": f"file not found: {exc.filename or exc}"})
+            raise typer.Exit(code=2)
+        except OSError as exc:
+            _print_error({"error": f"i/o error: {exc}"})
+            raise typer.Exit(code=2)
+        except Exception as exc:  # noqa: BLE001 - last-resort catch for the CLI boundary
+            _print_error(
+                {
+                    "error": str(exc) or repr(exc),
+                    "exception": type(exc).__name__,
+                }
+            )
+            raise typer.Exit(code=70)
+
+    return wrapper
+
+
+def _coerce_scalar(raw: str) -> Any:
+    """Best-effort coercion of CLI strings into JSON-native scalars.
+
+    The Veryfi API treats most fields as typed (numbers, booleans, nested
+    objects). We attempt JSON parsing first so callers can pass ``42``,
+    ``3.14``, ``true``, ``null``, or full JSON objects/arrays via
+    ``--field key=<json>``. If JSON parsing fails the value is kept as a
+    string, preserving the existing CLI ergonomics of plain text inputs.
+    """
+    if raw == "":
+        return ""
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return raw
+
+
+def parse_kv(pairs: Optional[Iterable[str]]) -> Dict[str, Any]:
+    """Convert ``["k=v", "k2=v2"]`` into a dict, coercing values via JSON."""
+    if not pairs:
+        return {}
+    result: Dict[str, Any] = {}
+    for raw in pairs:
+        if "=" not in raw:
+            raise typer.BadParameter(
+                f"--field expects KEY=VALUE, got {raw!r}",
+                param_hint="--field",
+            )
+        key, _, value = raw.partition("=")
+        key = key.strip()
+        if not key:
+            raise typer.BadParameter(
+                f"--field key cannot be empty (got {raw!r})",
+                param_hint="--field",
+            )
+        result[key] = _coerce_scalar(value)
+    return result
+
+
+def merge_body(
+    fields: Optional[Iterable[str]] = None,
+    json_body: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Combine ``--json-body`` with one or more ``--field KEY=VALUE`` overrides.
+
+    ``--field`` wins over ``--json-body`` so agents can layer ad-hoc tweaks
+    on top of a base payload.
+    """
+    body: Dict[str, Any] = {}
+    if json_body:
+        try:
+            parsed = json.loads(json_body)
+        except ValueError as exc:
+            raise typer.BadParameter(f"--json-body is not valid JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise typer.BadParameter("--json-body must be a JSON object")
+        body.update(parsed)
+    body.update(parse_kv(fields))
+    return body
+
+
+def read_file_arg(path: str) -> str:
+    """Resolve a ``--file`` argument to a real path on disk.
+
+    ``-`` reads bytes from stdin and stages them in a temp file so the SDK
+    methods (which require a path) keep working unchanged. The temp file is
+    cleaned up at interpreter exit.
+    """
+    if path != "-":
+        return path
+
+    import atexit
+    import tempfile
+
+    data = sys.stdin.buffer.read()
+    tmp = tempfile.NamedTemporaryFile(prefix="veryfi-stdin-", delete=False)
+    try:
+        tmp.write(data)
+    finally:
+        tmp.close()
+    atexit.register(lambda p=tmp.name: _safe_unlink(p))
+    return tmp.name
+
+
+def _safe_unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def optional_list(values: Optional[List[str]]) -> Optional[List[str]]:
+    """Normalise repeatable Typer options.
+
+    Typer passes an empty list for ``Option(None, ...)`` with ``--foo``
+    declared multiple times. We collapse that to ``None`` so the SDK
+    receives the same shape an explicit Python caller would pass.
+    """
+    if values is None:
+        return None
+    if len(values) == 0:
+        return None
+    return list(values)

--- a/veryfi/cli/a_docs.py
+++ b/veryfi/cli/a_docs.py
@@ -1,0 +1,119 @@
+"""CLI commands for the "Any Document" blueprint-based endpoint.
+
+Wraps :class:`veryfi.a_docs.ADocs`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="Any-document blueprint-based extraction.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    blueprint_name: str = typer.Option(..., "--blueprint", help="Blueprint name."),
+    file: str = typer.Option(..., "--file", "-f"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a local file with a custom blueprint."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_any_document(
+            blueprint_name=blueprint_name,
+            file_path=read_file_arg(file),
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    blueprint_name: str = typer.Option(..., "--blueprint"),
+    file_url: str = typer.Option(..., "--file-url"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a remote file with a custom blueprint."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_any_document_url(
+            blueprint_name=blueprint_name,
+            file_url=file_url,
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_any(
+    ctx: typer.Context,
+    created_date_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_date_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_date_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_date_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed any-documents."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_any_documents(
+            created_date__gt=created_date_gt,
+            created_date__gte=created_date_gte,
+            created_date__lt=created_date_lt,
+            created_date__lte=created_date_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_any(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single any-document by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_any_document(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("delete")
+@handle_errors
+def delete_any(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete an any-document."""
+    client = get_client(ctx)
+    client.delete_any_document(document_id=document_id)
+    emit(ctx, {"deleted": document_id})

--- a/veryfi/cli/bank_statements.py
+++ b/veryfi/cli/bank_statements.py
@@ -1,0 +1,122 @@
+"""CLI commands for bank statement documents.
+
+Wraps :class:`veryfi.bank_statements.BankStatements`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    optional_list,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="Bank statement documents.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f", help="Local file path, or '-' for stdin."),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    categories: Optional[List[str]] = typer.Option(
+        None, "--category", help="Optional category. Repeat for multiple."
+    ),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a bank statement from a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_bank_statement_document(
+            file_path=read_file_arg(file),
+            file_name=file_name,
+            categories=optional_list(categories),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    file_url: str = typer.Option(..., "--file-url"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    categories: Optional[List[str]] = typer.Option(None, "--category"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a bank statement from a URL."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_bank_statement_document_url(
+            file_url=file_url,
+            file_name=file_name,
+            categories=optional_list(categories),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_statements(
+    ctx: typer.Context,
+    created_date_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_date_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_date_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_date_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed bank statements."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_bank_statements(
+            created_date__gt=created_date_gt,
+            created_date__gte=created_date_gte,
+            created_date__lt=created_date_lt,
+            created_date__lte=created_date_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_statement(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single bank statement by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_bank_statement(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("delete")
+@handle_errors
+def delete_statement(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete a bank statement."""
+    client = get_client(ctx)
+    client.delete_bank_statement(document_id=document_id)
+    emit(ctx, {"deleted": document_id})

--- a/veryfi/cli/business_cards.py
+++ b/veryfi/cli/business_cards.py
@@ -1,0 +1,104 @@
+"""CLI commands for business cards.
+
+Wraps :class:`veryfi.bussines_cards.BussinesCards`. The (mis)spelled SDK
+method names are preserved on the Python side for backward compatibility;
+the CLI surface uses the correctly spelled noun ``business-cards``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="Business card documents.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a business card from a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_bussines_card_document(
+            file_path=read_file_arg(file),
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    file_url: str = typer.Option(..., "--file-url"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a business card from a URL."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_bussines_card_document_url(
+            file_url=file_url,
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_cards(
+    ctx: typer.Context,
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed business cards."""
+    client = get_client(ctx)
+    emit(ctx, client.get_business_cards(**parse_kv(extra)))
+
+
+@app.command("get")
+@handle_errors
+def get_card(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single business card by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_business_card(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("delete")
+@handle_errors
+def delete_card(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete a business card."""
+    client = get_client(ctx)
+    client.delete_business_card(document_id=document_id)
+    emit(ctx, {"deleted": document_id})

--- a/veryfi/cli/checks.py
+++ b/veryfi/cli/checks.py
@@ -1,0 +1,173 @@
+"""CLI commands for check documents.
+
+Wraps :class:`veryfi.checks.Checks`, including the ``-with-remittance``
+variants that hit a separate endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    optional_list,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="Check documents (including check-with-remittance).",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a check from a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_check(
+            file_path=read_file_arg(file),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    file_url: Optional[str] = typer.Option(None, "--file-url"),
+    file_urls: Optional[List[str]] = typer.Option(None, "--file-urls"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a check from a URL."""
+    if not file_url and not file_urls:
+        raise typer.BadParameter("either --file-url or --file-urls must be provided")
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_check_url(
+            file_url=file_url,
+            file_urls=optional_list(file_urls),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-with-remittance")
+@handle_errors
+def process_with_remittance(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a check together with its remittance attachment."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_check_with_remittance(
+            file_path=read_file_arg(file),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-with-remittance-url")
+@handle_errors
+def process_with_remittance_url(
+    ctx: typer.Context,
+    file_url: str = typer.Option(..., "--file-url"),
+    file_urls: Optional[List[str]] = typer.Option(None, "--file-urls"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a remote check + remittance from URLs."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_check_with_remittance_url(
+            file_url=file_url,
+            file_urls=optional_list(file_urls),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_checks(
+    ctx: typer.Context,
+    created_date_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_date_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_date_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_date_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed checks."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_checks(
+            created_date__gt=created_date_gt,
+            created_date__gte=created_date_gte,
+            created_date__lt=created_date_lt,
+            created_date__lte=created_date_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_check(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single check by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_check(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("update")
+@handle_errors
+def update_check(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Update fields on a check."""
+    body = merge_body(fields, json_body)
+    if not body:
+        raise typer.BadParameter("at least one --field or --json-body is required")
+    client = get_client(ctx)
+    emit(ctx, client.update_check(document_id=document_id, **body))
+
+
+@app.command("delete")
+@handle_errors
+def delete_check(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete a check."""
+    client = get_client(ctx)
+    client.delete_check(document_id=document_id)
+    emit(ctx, {"deleted": document_id})

--- a/veryfi/cli/classify.py
+++ b/veryfi/cli/classify.py
@@ -1,0 +1,75 @@
+"""CLI commands for the document classifier endpoint.
+
+Wraps :class:`veryfi.classify.Classify`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    optional_list,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="Classify a document into one of the supported types.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("file")
+@handle_errors
+def classify_file(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    document_types: Optional[List[str]] = typer.Option(
+        None,
+        "--document-type",
+        help="Candidate document type. Repeat for multiple (e.g. --document-type receipt).",
+    ),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Classify a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.classify_document(
+            file_path=read_file_arg(file),
+            document_types=optional_list(document_types),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("url")
+@handle_errors
+def classify_url(
+    ctx: typer.Context,
+    file_url: Optional[str] = typer.Option(None, "--file-url"),
+    file_urls: Optional[List[str]] = typer.Option(None, "--file-urls"),
+    document_types: Optional[List[str]] = typer.Option(None, "--document-type"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Classify a remote file."""
+    if not file_url and not file_urls:
+        raise typer.BadParameter("either --file-url or --file-urls must be provided")
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.classify_document_url(
+            file_url=file_url,
+            file_urls=optional_list(file_urls),
+            document_types=optional_list(document_types),
+            **merge_body(fields, json_body),
+        ),
+    )

--- a/veryfi/cli/documents.py
+++ b/veryfi/cli/documents.py
@@ -1,0 +1,462 @@
+"""CLI commands for receipts/invoice documents.
+
+Wraps :class:`veryfi.documents.Documents`, plus nested ``line-items``,
+``tags``, and PDF-split sub-apps.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    optional_list,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="Receipt and invoice documents.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+line_items_app = typer.Typer(
+    help="Line items belonging to a document.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+tags_app = typer.Typer(
+    help="Tags attached to a document.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+set_app = typer.Typer(
+    help="Multi-page PDF document sets (split-and-process).",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+app.add_typer(line_items_app, name="line-items")
+app.add_typer(tags_app, name="tags")
+app.add_typer(set_app, name="set")
+
+
+@app.command("process")
+@handle_errors
+def process_document(
+    ctx: typer.Context,
+    file: str = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        help="Path to a local file to upload, or '-' to read raw bytes from stdin.",
+    ),
+    categories: Optional[List[str]] = typer.Option(
+        None,
+        "--category",
+        help="Optional category. Repeat to pass multiple (e.g. --category Travel --category Meals).",
+    ),
+    delete_after_processing: bool = typer.Option(
+        False,
+        "--delete-after-processing/--keep",
+        help="Delete the document from Veryfi after extraction.",
+    ),
+    fields: Optional[List[str]] = typer.Option(
+        None,
+        "--field",
+        help="Extra body parameter KEY=VALUE. Repeat for multiple.",
+    ),
+    json_body: Optional[str] = typer.Option(
+        None,
+        "--json-body",
+        help="Extra body parameters as a JSON object. Merged before --field overrides.",
+    ),
+) -> None:
+    """Upload a receipt or invoice and extract structured data."""
+    client = get_client(ctx)
+    result = client.process_document(
+        file_path=read_file_arg(file),
+        categories=optional_list(categories),
+        delete_after_processing=delete_after_processing,
+        **merge_body(fields, json_body),
+    )
+    emit(ctx, result)
+
+
+@app.command("process-url")
+@handle_errors
+def process_document_url(
+    ctx: typer.Context,
+    file_url: Optional[str] = typer.Option(
+        None, "--file-url", help="Publicly accessible URL of the file."
+    ),
+    file_urls: Optional[List[str]] = typer.Option(
+        None,
+        "--file-urls",
+        help="Publicly accessible URLs (repeat the flag). Alternative to --file-url.",
+    ),
+    categories: Optional[List[str]] = typer.Option(None, "--category"),
+    delete_after_processing: bool = typer.Option(False, "--delete-after-processing/--keep"),
+    boost_mode: bool = typer.Option(False, "--boost-mode/--no-boost-mode"),
+    external_id: Optional[str] = typer.Option(
+        None, "--external-id", help="Optional custom ID to attach to the document."
+    ),
+    max_pages_to_process: Optional[int] = typer.Option(
+        None, "--max-pages", help="Cap processing at this many pages."
+    ),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a remote receipt or invoice by URL."""
+    if not file_url and not file_urls:
+        raise typer.BadParameter("either --file-url or --file-urls must be provided")
+    client = get_client(ctx)
+    result = client.process_document_url(
+        file_url=file_url,
+        file_urls=optional_list(file_urls),
+        categories=optional_list(categories),
+        delete_after_processing=delete_after_processing,
+        boost_mode=boost_mode,
+        external_id=external_id,
+        max_pages_to_process=max_pages_to_process,
+        **merge_body(fields, json_body),
+    )
+    emit(ctx, result)
+
+
+@app.command("process-bulk")
+@handle_errors
+def process_documents_bulk(
+    ctx: typer.Context,
+    file_urls: List[str] = typer.Option(
+        ...,
+        "--file-url",
+        help="Publicly accessible URL. Repeat the flag for each file.",
+    ),
+) -> None:
+    """Submit several remote URLs in a single bulk request."""
+    client = get_client(ctx)
+    emit(ctx, client.process_documents_bulk(file_urls=list(file_urls)))
+
+
+@app.command("list")
+@handle_errors
+def list_documents(
+    ctx: typer.Context,
+    q: Optional[str] = typer.Option(None, "--q", help="Free-text search query."),
+    external_id: Optional[str] = typer.Option(None, "--external-id"),
+    tag: Optional[str] = typer.Option(None, "--tag"),
+    created_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(
+        None, "--param", help="Extra query parameter KEY=VALUE. Repeat for multiple."
+    ),
+) -> None:
+    """Search/list previously processed documents."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_documents(
+            q=q,
+            external_id=external_id,
+            tag=tag,
+            created_gt=created_gt,
+            created_gte=created_gte,
+            created_lt=created_lt,
+            created_lte=created_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_document(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(..., help="Document ID."),
+    extra: Optional[List[str]] = typer.Option(
+        None, "--param", help="Extra query parameter KEY=VALUE. Repeat for multiple."
+    ),
+) -> None:
+    """Fetch a single document by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_document(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("update")
+@handle_errors
+def update_document(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(..., help="Document ID."),
+    fields: Optional[List[str]] = typer.Option(
+        None,
+        "--field",
+        help="Field to update: KEY=VALUE. Repeat for multiple.",
+    ),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Update mutable fields on a document."""
+    body = merge_body(fields, json_body)
+    if not body:
+        raise typer.BadParameter("at least one --field or --json-body is required")
+    client = get_client(ctx)
+    emit(ctx, client.update_document(document_id=document_id, **body))
+
+
+@app.command("delete")
+@handle_errors
+def delete_document(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(..., help="Document ID."),
+) -> None:
+    """Delete a document."""
+    client = get_client(ctx)
+    client.delete_document(document_id=document_id)
+    emit(ctx, {"deleted": document_id})
+
+
+# --- line-items sub-app ------------------------------------------------------
+
+
+@line_items_app.command("list")
+@handle_errors
+def line_items_list(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(..., help="Parent document ID."),
+) -> None:
+    """List all line items on a document."""
+    client = get_client(ctx)
+    emit(ctx, client.get_line_items(document_id=document_id))
+
+
+@line_items_app.command("get")
+@handle_errors
+def line_item_get(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    line_item_id: int = typer.Argument(...),
+) -> None:
+    """Fetch a single line item."""
+    client = get_client(ctx)
+    emit(ctx, client.get_line_item(document_id=document_id, line_item_id=line_item_id))
+
+
+@line_items_app.command("add")
+@handle_errors
+def line_item_add(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Append a new line item."""
+    payload = merge_body(fields, json_body)
+    if not payload:
+        raise typer.BadParameter("at least one --field or --json-body is required")
+    client = get_client(ctx)
+    emit(ctx, client.add_line_item(document_id=document_id, payload=payload))
+
+
+@line_items_app.command("update")
+@handle_errors
+def line_item_update(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    line_item_id: int = typer.Argument(...),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Update an existing line item."""
+    payload = merge_body(fields, json_body)
+    if not payload:
+        raise typer.BadParameter("at least one --field or --json-body is required")
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.update_line_item(
+            document_id=document_id, line_item_id=line_item_id, payload=payload
+        ),
+    )
+
+
+@line_items_app.command("delete")
+@handle_errors
+def line_item_delete(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    line_item_id: int = typer.Argument(...),
+) -> None:
+    """Delete a single line item."""
+    client = get_client(ctx)
+    client.delete_line_item(document_id=document_id, line_item_id=line_item_id)
+    emit(ctx, {"deleted": {"document_id": document_id, "line_item_id": line_item_id}})
+
+
+@line_items_app.command("delete-all")
+@handle_errors
+def line_items_delete_all(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete every line item on a document."""
+    client = get_client(ctx)
+    client.delete_line_items(document_id=document_id)
+    emit(ctx, {"deleted_all_on_document": document_id})
+
+
+# --- tags sub-app ------------------------------------------------------------
+
+
+@tags_app.command("list")
+@handle_errors
+def tags_list(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """List tags on a document."""
+    client = get_client(ctx)
+    emit(ctx, client.get_tags(document_id=document_id))
+
+
+@tags_app.command("add")
+@handle_errors
+def tags_add(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    name: str = typer.Option(..., "--name", help="Tag name to attach."),
+) -> None:
+    """Attach a single tag."""
+    client = get_client(ctx)
+    emit(ctx, client.add_tag(document_id=document_id, tag_name=name))
+
+
+@tags_app.command("add-many")
+@handle_errors
+def tags_add_many(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    tags: List[str] = typer.Option(..., "--tag", help="Tag name. Repeat for multiple."),
+) -> None:
+    """Attach several tags at once."""
+    client = get_client(ctx)
+    emit(ctx, client.add_tags(document_id=document_id, tags=list(tags)))
+
+
+@tags_app.command("replace")
+@handle_errors
+def tags_replace(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    tags: List[str] = typer.Option(..., "--tag", help="Replacement tag name. Repeat for multiple."),
+) -> None:
+    """Replace all tags with the supplied set."""
+    client = get_client(ctx)
+    emit(ctx, client.replace_tags(document_id=document_id, tags=list(tags)))
+
+
+@tags_app.command("delete")
+@handle_errors
+def tags_delete(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    tag_id: int = typer.Argument(...),
+) -> None:
+    """Detach a single tag."""
+    client = get_client(ctx)
+    client.delete_tag(document_id=document_id, tag_id=tag_id)
+    emit(ctx, {"deleted": {"document_id": document_id, "tag_id": tag_id}})
+
+
+@tags_app.command("delete-all")
+@handle_errors
+def tags_delete_all(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Detach every tag from a document."""
+    client = get_client(ctx)
+    client.delete_tags(document_id=document_id)
+    emit(ctx, {"deleted_all_on_document": document_id})
+
+
+# --- document-set / PDF split sub-app ---------------------------------------
+
+
+@set_app.command("split")
+@handle_errors
+def split_pdf(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f", help="Local PDF path, or '-' for stdin."),
+    categories: Optional[List[str]] = typer.Option(None, "--category"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Split a multi-page PDF and process each page."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.split_and_process_pdf(
+            file_path=read_file_arg(file),
+            categories=optional_list(categories),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@set_app.command("split-url")
+@handle_errors
+def split_pdf_url(
+    ctx: typer.Context,
+    file_url: Optional[str] = typer.Option(None, "--file-url"),
+    file_urls: Optional[List[str]] = typer.Option(None, "--file-urls"),
+    categories: Optional[List[str]] = typer.Option(None, "--category"),
+    max_pages_to_process: Optional[int] = typer.Option(None, "--max-pages"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Split a remote PDF and process each page."""
+    if not file_url and not file_urls:
+        raise typer.BadParameter("either --file-url or --file-urls must be provided")
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.split_and_process_pdf_url(
+            file_url=file_url,
+            file_urls=optional_list(file_urls),
+            categories=optional_list(categories),
+            max_pages_to_process=max_pages_to_process,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@set_app.command("list")
+@handle_errors
+def set_list(
+    ctx: typer.Context,
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed PDF document sets."""
+    client = get_client(ctx)
+    emit(ctx, client.get_pdf(**parse_kv(extra)))
+
+
+@set_app.command("get")
+@handle_errors
+def set_get(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(..., help="Document-set ID."),
+) -> None:
+    """Fetch all documents inside a PDF set."""
+    client = get_client(ctx)
+    emit(ctx, client.get_documents_from_pdf(document_id=document_id))

--- a/veryfi/cli/w2s.py
+++ b/veryfi/cli/w2s.py
@@ -1,0 +1,193 @@
+"""CLI commands for W-2 documents.
+
+Wraps :class:`veryfi.w2s.W2s`, including the multi-W-2 split operations
+inherited from :class:`veryfi._w2s.w2_split.W2Split`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    optional_list,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="W-2 forms.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+set_app = typer.Typer(
+    help="Multi-W-2 PDF document sets (split-and-process).",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+app.add_typer(set_app, name="set")
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a W-2 from a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_w2_document(
+            file_path=read_file_arg(file),
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    file_url: str = typer.Option(..., "--file-url"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a W-2 from a URL."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_w2_document_url(
+            file_url=file_url,
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_w2s(
+    ctx: typer.Context,
+    created_date_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_date_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_date_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_date_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed W-2s."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_w2s(
+            created_date_gt=created_date_gt,
+            created_date_gte=created_date_gte,
+            created_date_lt=created_date_lt,
+            created_date_lte=created_date_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_w2(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single W-2 by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_w2(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("delete")
+@handle_errors
+def delete_w2(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete a W-2."""
+    client = get_client(ctx)
+    client.delete_w2(document_id=document_id)
+    emit(ctx, {"deleted": document_id})
+
+
+# --- W-2 document-set sub-app -----------------------------------------------
+
+
+@set_app.command("split")
+@handle_errors
+def split_w2(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Split a multi-W-2 PDF and process each page."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.split_and_process_w2(
+            file_path=read_file_arg(file),
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@set_app.command("split-url")
+@handle_errors
+def split_w2_url(
+    ctx: typer.Context,
+    file_url: Optional[str] = typer.Option(None, "--file-url"),
+    file_urls: Optional[List[str]] = typer.Option(None, "--file-urls"),
+    max_pages_to_process: Optional[int] = typer.Option(None, "--max-pages"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Split a remote multi-W-2 PDF and process each page."""
+    if not file_url and not file_urls:
+        raise typer.BadParameter("either --file-url or --file-urls must be provided")
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.split_and_process_w2_url(
+            file_url=file_url,
+            file_urls=optional_list(file_urls),
+            max_pages_to_process=max_pages_to_process,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@set_app.command("list")
+@handle_errors
+def set_list(
+    ctx: typer.Context,
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List W-2 document sets."""
+    client = get_client(ctx)
+    emit(ctx, client.get_list_of_w2s(**parse_kv(extra)))
+
+
+@set_app.command("get")
+@handle_errors
+def set_get(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Fetch all W-2s inside a document set."""
+    client = get_client(ctx)
+    emit(ctx, client.get_documents_from_w2(document_id=document_id))

--- a/veryfi/cli/w8s.py
+++ b/veryfi/cli/w8s.py
@@ -1,0 +1,115 @@
+"""CLI commands for W-8 BEN-E documents.
+
+Wraps :class:`veryfi.w8s.W8s`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="W-8 BEN-E forms.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a W-8 from a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_w8_document(
+            file_path=read_file_arg(file),
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    file_url: str = typer.Option(..., "--file-url"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a W-8 from a URL."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_w8_document_url(
+            file_url=file_url,
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_w8s(
+    ctx: typer.Context,
+    created_date_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_date_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_date_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_date_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed W-8s."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_w8s(
+            created_date_gt=created_date_gt,
+            created_date_gte=created_date_gte,
+            created_date_lt=created_date_lt,
+            created_date_lte=created_date_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_w8(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single W-8 by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_w8(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("delete")
+@handle_errors
+def delete_w8(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete a W-8."""
+    client = get_client(ctx)
+    client.delete_w8(document_id=document_id)
+    emit(ctx, {"deleted": document_id})

--- a/veryfi/cli/w9s.py
+++ b/veryfi/cli/w9s.py
@@ -1,0 +1,115 @@
+"""CLI commands for W-9 documents.
+
+Wraps :class:`veryfi.w9s.W9s`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from veryfi.cli._common import (
+    emit,
+    get_client,
+    handle_errors,
+    merge_body,
+    parse_kv,
+    read_file_arg,
+)
+
+app = typer.Typer(
+    help="W-9 forms.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+)
+
+
+@app.command("process")
+@handle_errors
+def process(
+    ctx: typer.Context,
+    file: str = typer.Option(..., "--file", "-f"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a W-9 from a local file."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_w9_document(
+            file_path=read_file_arg(file),
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("process-url")
+@handle_errors
+def process_url(
+    ctx: typer.Context,
+    file_url: str = typer.Option(..., "--file-url"),
+    file_name: Optional[str] = typer.Option(None, "--file-name"),
+    fields: Optional[List[str]] = typer.Option(None, "--field"),
+    json_body: Optional[str] = typer.Option(None, "--json-body"),
+) -> None:
+    """Process a W-9 from a URL."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.process_w9_document_url(
+            file_url=file_url,
+            file_name=file_name,
+            **merge_body(fields, json_body),
+        ),
+    )
+
+
+@app.command("list")
+@handle_errors
+def list_w9s(
+    ctx: typer.Context,
+    created_date_gt: Optional[str] = typer.Option(None, "--created-gt"),
+    created_date_gte: Optional[str] = typer.Option(None, "--created-gte"),
+    created_date_lt: Optional[str] = typer.Option(None, "--created-lt"),
+    created_date_lte: Optional[str] = typer.Option(None, "--created-lte"),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """List previously processed W-9s."""
+    client = get_client(ctx)
+    emit(
+        ctx,
+        client.get_w9s(
+            created_date_gt=created_date_gt,
+            created_date_gte=created_date_gte,
+            created_date_lt=created_date_lt,
+            created_date_lte=created_date_lte,
+            **parse_kv(extra),
+        ),
+    )
+
+
+@app.command("get")
+@handle_errors
+def get_w9(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+    extra: Optional[List[str]] = typer.Option(None, "--param"),
+) -> None:
+    """Fetch a single W-9 by ID."""
+    client = get_client(ctx)
+    emit(ctx, client.get_w9(document_id=document_id, **parse_kv(extra)))
+
+
+@app.command("delete")
+@handle_errors
+def delete_w9(
+    ctx: typer.Context,
+    document_id: int = typer.Argument(...),
+) -> None:
+    """Delete a W-9."""
+    client = get_client(ctx)
+    client.delete_w9(document_id=document_id)
+    emit(ctx, {"deleted": document_id})

--- a/veryfi/client_base.py
+++ b/veryfi/client_base.py
@@ -10,6 +10,24 @@ import requests
 from veryfi.errors import VeryfiClientError
 
 
+def _resolve_package_version() -> str:
+    """Resolve the installed package version once at import time.
+
+    Using ``importlib.metadata`` keeps the User-Agent in sync with whatever
+    ``pbr`` baked from the git tag at release time, so we never have to
+    remember to bump a literal here when cutting a new version.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("veryfi")
+    except Exception:
+        return "unknown"
+
+
+_PACKAGE_VERSION = _resolve_package_version()
+
+
 class Client:
     API_VERSION = "v8"
     API_TIMEOUT = 30
@@ -42,7 +60,7 @@ class Client:
         :return: Dictionary with headers
         """
         final_headers = {
-            "User-Agent": "Python Veryfi-Python/5.0.1",
+            "User-Agent": f"Python Veryfi-Python/{_PACKAGE_VERSION}",
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Client-Id": self.client_id,


### PR DESCRIPTION
## Summary

Adds a Typer-based `veryfi` command-line interface that wraps every public `Client` method, so AI agents and shell users can drive the SDK from a terminal. The CLI is purely additive — `Client`'s constructor signature, public methods, and all existing tests are unchanged.

Resolves the gap that today an AI agent capable of spawning shell commands cannot call `process_document`, `classify_document`, etc., because the package ships no `console_scripts` entry point and no `__main__.py`.

## What's new

- **Console entry points**: installing `veryfi` now registers a `veryfi` shell command (via `console_scripts` in [setup.cfg](setup.cfg)) and `python -m veryfi` works via [veryfi/__main__.py](veryfi/__main__.py).
- **One Typer sub-app per resource** under [veryfi/cli/](veryfi/cli/): `documents` (incl. nested `line-items`, `tags`, `set` PDF-split), `bank-statements`, `checks` (incl. with-remittance), `business-cards`, `w2s` (incl. `set` W-2 split), `w8s`, `w9s`, `any-docs`, `classify`.
- **Env-var-first auth**: `VERYFI_CLIENT_ID`, `VERYFI_USERNAME`, `VERYFI_API_KEY` (plus optional `VERYFI_CLIENT_SECRET`, `VERYFI_BASE_URL`, `VERYFI_API_VERSION`, `VERYFI_TIMEOUT`). Equivalent `--flags` override env. Missing creds exit `2` with a JSON error on stderr.
- **Agent-friendly I/O**: JSON to stdout (with `--output json|raw|pretty`), structured JSON errors to stderr, exit codes mapped from the HTTP status (clipped to 1–255) so agents can branch without parsing tracebacks.
- **Machine-readable discovery**: `veryfi schema` emits a JSON manifest of every command and parameter, so agents and MCP servers can register Veryfi as a tool surface without parsing `--help` text.
- **Repeatable `--field KEY=VALUE` / `--json-body`** for endpoints that take `**kwargs` (`update_document`, `add_line_item`, `update_check`, …). Values are JSON-coerced (`total=11.23` becomes a number, `enabled=true` becomes a boolean, full JSON objects are accepted).
- **stdin support**: `--file -` reads bytes from stdin and stages them in a temp file, useful for pipelines (`curl … | veryfi documents process --file -`).
- **Dynamic User-Agent** in [veryfi/client_base.py](veryfi/client_base.py): resolved at import time via `importlib.metadata.version(\"veryfi\")` so it tracks the `pbr`-derived version automatically. No more manual bumps of the hard-coded `5.0.1` string.

## Files

- New: [veryfi/__main__.py](veryfi/__main__.py), [veryfi/cli/](veryfi/cli/) (10 modules: `__init__.py`, `_common.py`, plus one per resource), [tests/test_cli.py](tests/test_cli.py).
- Edited: [setup.cfg](setup.cfg) (new `console_scripts` group + `install_requires` with `typer>=0.12.0`), [requirements.txt](requirements.txt), [Pipfile](Pipfile), [README.md](README.md) (new \"Command-line interface\" section), [veryfi/client_base.py](veryfi/client_base.py) (dynamic User-Agent only — no behavior change).

## Backward compatibility

- `Client` constructor signature is byte-identical.
- All public methods are unchanged. The misspelled `process_bussines_card_document` is preserved (the CLI exposes the correctly spelled `veryfi business-cards process` on top).
- All 35 existing tests pass untouched.
- New runtime dep: `typer>=0.12.0`. Consistent with how the project added new features in prior minor releases (e.g. line-items in 3.1.0, tags in 3.4.0).

## Versioning

Recommended bump: **5.1.0** (minor — additive feature). `pbr` will pick this up automatically from the next git tag, and the User-Agent will follow.

## Test plan

- [x] `python -m pytest tests/ -q` — 62 passed (35 existing + 27 new).
- [x] `black --check .` — clean across 45 files.
- [x] `python -m veryfi --help` lists all 9 resource groups + `schema`.
- [x] `python -m veryfi schema | jq` returns the full command manifest.
- [x] `python -m veryfi documents get 1` with no env vars exits `2` with JSON on stderr.
- [x] `pip install -e .` registers the `veryfi` console script and it works end-to-end.
- [ ] CI green on this PR.

## Try it out

```bash
export VERYFI_CLIENT_ID=... VERYFI_USERNAME=... VERYFI_API_KEY=...
veryfi documents process --file /tmp/receipt.jpg --category Travel
veryfi classify file --file /tmp/unknown.pdf --document-type receipt --document-type invoice
veryfi schema | jq '.commands[] | .name'
```

See the new \"Command-line interface\" section in [README.md](README.md) for the full reference.