### PR TITLE
Refresh PyPI version badge (bust Camo cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # veryfi-python
 
-[![PyPI - version](https://img.shields.io/pypi/v/veryfi.svg)](https://pypi.python.org/pypi/veryfi/)
-[![PyPI](https://img.shields.io/pypi/pyversions/veryfi.svg)](https://pypi.python.org/pypi/veryfi)
+[![PyPI - version](https://img.shields.io/pypi/v/veryfi.svg?v=5.1.0)](https://pypi.python.org/pypi/veryfi/)
+[![PyPI](https://img.shields.io/pypi/pyversions/veryfi.svg?v=5.1.0)](https://pypi.python.org/pypi/veryfi)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Test](https://github.com/veryfi/veryfi-python/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/veryfi/veryfi-python/actions/workflows/test.yml)
 


### PR DESCRIPTION
GitHub's image proxy is serving a cached 5.0.1 PNG of the shields.io PyPI badge, even though PyPI and shields.io have already updated to 5.1.0. Appending `?v=5.1.0` to the badge URLs makes GitHub treat them as new URLs and fetch fresh copies. No-op as far as shields.io is concerned.